### PR TITLE
fix: support multiple sessions per hub connection

### DIFF
--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -80,12 +80,12 @@ func (h *sseHandlers) connect(w http.ResponseWriter, r *http.Request) {
 	conn := h.hub.Register(agentID, consumerID)
 	connGen := conn.Generation()
 	defer func() {
-		sessionID := h.hub.GetSessionID(agentID, consumerID, connGen)
+		sessionIDs := h.hub.GetSessionIDs(agentID, consumerID, connGen)
 		h.hub.Unregister(agentID, consumerID, connGen)
-		if sessionID != "" {
+		for _, sessionID := range sessionIDs {
 			disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer disconnectCancel()
 			h.kernel.HandleAgentDisconnect(disconnectCtx, sessionID)
+			disconnectCancel()
 		}
 	}()
 

--- a/internal/hub/conn.go
+++ b/internal/hub/conn.go
@@ -13,9 +13,9 @@ var epoch atomic.Uint64
 type Conn struct {
 	AgentID    string
 	ConsumerID string
-	SessionID  string
 	EventCh    chan store.AgentMessage
 	generation uint64
+	sessionIDs map[string]struct{}
 }
 
 func NewConn(agentID, consumerID string) *Conn {
@@ -24,6 +24,7 @@ func NewConn(agentID, consumerID string) *Conn {
 		ConsumerID: consumerID,
 		EventCh:    make(chan store.AgentMessage, eventChannelSize),
 		generation: epoch.Add(1),
+		sessionIDs: make(map[string]struct{}),
 	}
 }
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -40,8 +40,8 @@ func (h *Hub) Register(agentID, consumerID string) *Conn {
 
 	if old, ok := h.agents[agentID][consumerID]; ok {
 		close(old.EventCh)
-		if old.SessionID != "" {
-			delete(h.sessions, old.SessionID)
+		for sid := range old.sessionIDs {
+			delete(h.sessions, sid)
 		}
 	}
 
@@ -73,8 +73,8 @@ func (h *Hub) Unregister(agentID, consumerID string, generation uint64) {
 		return
 	}
 
-	if conn.SessionID != "" {
-		delete(h.sessions, conn.SessionID)
+	for sid := range conn.sessionIDs {
+		delete(h.sessions, sid)
 	}
 	close(conn.EventCh)
 	delete(consumers, consumerID)
@@ -90,22 +90,26 @@ func (h *Hub) Unregister(agentID, consumerID string, generation uint64) {
 	)
 }
 
-func (h *Hub) GetSessionID(agentID, consumerID string, generation uint64) string {
+func (h *Hub) GetSessionIDs(agentID, consumerID string, generation uint64) []string {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
 	consumers, ok := h.agents[agentID]
 	if !ok {
-		return ""
+		return nil
 	}
 	conn, ok := consumers[consumerID]
 	if !ok {
-		return ""
+		return nil
 	}
 	if conn.generation != generation {
-		return ""
+		return nil
 	}
-	return conn.SessionID
+	ids := make([]string, 0, len(conn.sessionIDs))
+	for sid := range conn.sessionIDs {
+		ids = append(ids, sid)
+	}
+	return ids
 }
 
 func (h *Hub) SetSession(agentID, consumerID, sessionID string) {
@@ -121,12 +125,25 @@ func (h *Hub) SetSession(agentID, consumerID, sessionID string) {
 		return
 	}
 
-	if conn.SessionID != "" {
-		delete(h.sessions, conn.SessionID)
+	conn.sessionIDs[sessionID] = struct{}{}
+	h.sessions[sessionID] = conn
+}
+
+func (h *Hub) RemoveSession(agentID, consumerID, sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	consumers, ok := h.agents[agentID]
+	if !ok {
+		return
+	}
+	conn, ok := consumers[consumerID]
+	if !ok {
+		return
 	}
 
-	conn.SessionID = sessionID
-	h.sessions[sessionID] = conn
+	delete(conn.sessionIDs, sessionID)
+	delete(h.sessions, sessionID)
 }
 
 func (h *Hub) Send(agentID string, msg store.AgentMessage) bool {
@@ -143,8 +160,8 @@ func (h *Hub) Send(agentID string, msg store.AgentMessage) bool {
 			slog.String("agent_id", agentID),
 			slog.String("consumer_id", conn.ConsumerID),
 		)
-		if conn.SessionID != "" {
-			delete(h.sessions, conn.SessionID)
+		for sid := range conn.sessionIDs {
+			delete(h.sessions, sid)
 		}
 		close(conn.EventCh)
 		delete(h.agents[agentID], conn.ConsumerID)
@@ -194,7 +211,6 @@ func (h *Hub) PickConnection(agentID string) (store.ConnInfo, bool) {
 
 	return store.ConnInfo{
 		ConsumerID: conn.ConsumerID,
-		SessionID:  conn.SessionID,
 	}, true
 }
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -329,52 +329,107 @@ func TestSendFullChannelEvictsSessionToo(t *testing.T) {
 	}
 }
 
-func TestSetSessionReplacePrevious(t *testing.T) {
+func TestMultipleSessionsPerConnection(t *testing.T) {
 	h := New(nil)
 	defer h.Close()
 
-	h.Register("agent-1", "c1")
-	h.SetSession("agent-1", "c1", "session-old")
+	conn := h.Register("agent-1", "c1")
+	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
 
-	if ok := h.SendToSession("session-old", testMsg("test")); !ok {
-		t.Fatal("expected old session to be reachable")
+	if ok := h.SendToSession("session-1", testMsg("msg-1")); !ok {
+		t.Fatal("expected session-1 to be reachable")
+	}
+	if ok := h.SendToSession("session-2", testMsg("msg-2")); !ok {
+		t.Fatal("expected session-2 to be reachable")
 	}
 
-	h.SetSession("agent-1", "c1", "session-new")
-
-	if ok := h.SendToSession("session-old", testMsg("test")); ok {
-		t.Fatal("expected old session to be unreachable after replacement")
+	// Both messages should arrive on the same connection channel
+	received := 0
+	for i := 0; i < 2; i++ {
+		select {
+		case <-conn.EventCh:
+			received++
+		default:
+		}
 	}
-	if ok := h.SendToSession("session-new", testMsg("test")); !ok {
-		t.Fatal("expected new session to be reachable")
+	if received != 2 {
+		t.Fatalf("expected 2 messages, got %d", received)
 	}
 }
 
-func TestGetSessionID(t *testing.T) {
+func TestMultipleSessionsClearedOnUnregister(t *testing.T) {
+	h := New(nil)
+	defer h.Close()
+
+	conn := h.Register("agent-1", "c1")
+	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
+
+	h.Unregister("agent-1", "c1", conn.Generation())
+
+	if ok := h.SendToSession("session-1", testMsg("test")); ok {
+		t.Fatal("expected session-1 to be unreachable after unregister")
+	}
+	if ok := h.SendToSession("session-2", testMsg("test")); ok {
+		t.Fatal("expected session-2 to be unreachable after unregister")
+	}
+}
+
+func TestGetSessionIDs(t *testing.T) {
 	h := New(nil)
 	defer h.Close()
 
 	conn := h.Register("agent-1", "c1")
 	gen := conn.Generation()
 
-	if s := h.GetSessionID("agent-1", "c1", gen); s != "" {
-		t.Fatalf("expected empty session before SetSession, got %q", s)
+	ids := h.GetSessionIDs("agent-1", "c1", gen)
+	if len(ids) != 0 {
+		t.Fatalf("expected empty session IDs before SetSession, got %v", ids)
 	}
 
 	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
 
-	if s := h.GetSessionID("agent-1", "c1", gen); s != "session-1" {
-		t.Fatalf("expected 'session-1', got %q", s)
+	ids = h.GetSessionIDs("agent-1", "c1", gen)
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 session IDs, got %d", len(ids))
 	}
 
-	// Stale generation returns empty
-	if s := h.GetSessionID("agent-1", "c1", gen-1); s != "" {
-		t.Fatalf("expected empty for stale generation, got %q", s)
+	found := make(map[string]bool)
+	for _, id := range ids {
+		found[id] = true
+	}
+	if !found["session-1"] || !found["session-2"] {
+		t.Fatalf("expected session-1 and session-2, got %v", ids)
 	}
 
-	// Missing agent returns empty
-	if s := h.GetSessionID("nonexistent", "c1", gen); s != "" {
-		t.Fatalf("expected empty for missing agent, got %q", s)
+	// Stale generation returns nil
+	if ids := h.GetSessionIDs("agent-1", "c1", gen-1); len(ids) != 0 {
+		t.Fatalf("expected nil for stale generation, got %v", ids)
+	}
+
+	// Missing agent returns nil
+	if ids := h.GetSessionIDs("nonexistent", "c1", gen); len(ids) != 0 {
+		t.Fatalf("expected nil for missing agent, got %v", ids)
+	}
+}
+
+func TestRemoveSession(t *testing.T) {
+	h := New(nil)
+	defer h.Close()
+
+	h.Register("agent-1", "c1")
+	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
+
+	h.RemoveSession("agent-1", "c1", "session-1")
+
+	if ok := h.SendToSession("session-1", testMsg("test")); ok {
+		t.Fatal("expected session-1 to be unreachable after removal")
+	}
+	if ok := h.SendToSession("session-2", testMsg("test")); !ok {
+		t.Fatal("expected session-2 to still be reachable")
 	}
 }
 
@@ -471,4 +526,44 @@ func TestConcurrentRegisterUnregisterSameAgent(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestMultipleSessionsOverflowEvictsAll(t *testing.T) {
+	h := New(nil)
+	defer h.Close()
+
+	conn := h.Register("agent-1", "c1")
+	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
+
+	for i := 0; i < eventChannelSize; i++ {
+		conn.EventCh <- testMsg("fill")
+	}
+
+	h.Send("agent-1", testMsg("overflow"))
+
+	if ok := h.SendToSession("session-1", testMsg("test")); ok {
+		t.Fatal("expected session-1 to be cleaned up after overflow")
+	}
+	if ok := h.SendToSession("session-2", testMsg("test")); ok {
+		t.Fatal("expected session-2 to be cleaned up after overflow")
+	}
+}
+
+func TestReRegisterClearsAllSessions(t *testing.T) {
+	h := New(nil)
+	defer h.Close()
+
+	h.Register("agent-1", "c1")
+	h.SetSession("agent-1", "c1", "session-1")
+	h.SetSession("agent-1", "c1", "session-2")
+
+	h.Register("agent-1", "c1")
+
+	if ok := h.SendToSession("session-1", testMsg("test")); ok {
+		t.Fatal("expected session-1 to be gone after re-register")
+	}
+	if ok := h.SendToSession("session-2", testMsg("test")); ok {
+		t.Fatal("expected session-2 to be gone after re-register")
+	}
 }

--- a/internal/kernel/mock_test.go
+++ b/internal/kernel/mock_test.go
@@ -163,7 +163,7 @@ func newConnectedMockAgentHub() *mockAgentHub {
 	return &mockAgentHub{
 		sessions: make(map[string]store.AgentMessage),
 		hasConn:  true,
-		connInfo: store.ConnInfo{ConsumerID: "test-consumer", SessionID: ""},
+		connInfo: store.ConnInfo{ConsumerID: "test-consumer"},
 	}
 }
 

--- a/internal/store/agenthub.go
+++ b/internal/store/agenthub.go
@@ -9,7 +9,6 @@ type AgentMessage struct {
 
 type ConnInfo struct {
 	ConsumerID string
-	SessionID  string
 }
 
 type AgentHub interface {


### PR DESCRIPTION
Fixes https://github.com/rebuno/rebuno/issues/3

## Summary

- Change hub `Conn` from tracking a single `SessionID` to a set of `sessionIDs`, allowing multiple concurrent sessions on one SSE connection
- Add `RemoveSession` method for granular session cleanup without tearing down the whole connection
- Update `GetSessionID` → `GetSessionIDs` to return all sessions for a connection generation
- Fix SSE disconnect handler to iterate over all sessions and properly cancel each context
- Remove `SessionID` from `ConnInfo` since it's no longer a single value
- Add comprehensive tests: multi-session send, unregister cleanup, remove individual session, overflow eviction, and re-register clearing

## Test plan
- [x] `TestMultipleSessionsPerConnection` — both sessions receive messages on the same channel
- [x] `TestMultipleSessionsClearedOnUnregister` — all sessions cleaned up on unregister
- [x] `TestGetSessionIDs` — returns correct set, handles stale generation and missing agent
- [x] `TestRemoveSession` — individual session removal leaves others intact
- [x] `TestMultipleSessionsOverflowEvictsAll` — channel overflow evicts all sessions
- [x] `TestReRegisterClearsAllSessions` — re-registering same agent/consumer clears old sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)