### PR TITLE
Fix orphaned steps blocking tool invocations after agent disconnect

### DIFF
--- a/internal/kernel/disconnect.go
+++ b/internal/kernel/disconnect.go
@@ -67,6 +67,19 @@ func (k *Kernel) HandleAgentDisconnect(ctx context.Context, sessionID string) {
 
 	switch state.Execution.Status {
 	case domain.ExecutionRunning:
+		for stepID, step := range state.Steps {
+			if step.Status.IsTerminal() {
+				continue
+			}
+			if _, err := k.EmitEvent(ctx, executionID, stepID, domain.EventStepCancelled,
+				domain.StepCancelledPayload{Reason: "agent disconnected"}, uuid.Nil, correlationID); err != nil {
+				k.logger.Warn("disconnect: failed to cancel orphaned step",
+					slog.String("execution_id", executionID),
+					slog.String("step_id", stepID),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
 		_, err = k.EmitEvent(ctx, executionID, "", domain.EventExecutionReset,
 			domain.ExecutionResetPayload{
 				Reason:     "agent_disconnect",

--- a/internal/kernel/disconnect_test.go
+++ b/internal/kernel/disconnect_test.go
@@ -1,0 +1,190 @@
+package kernel
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/rebuno/rebuno/internal/domain"
+)
+
+func TestHandleAgentDisconnectCancelsOrphanedSteps(t *testing.T) {
+	k, events, _, _, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+
+	result, err := k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent: domain.Intent{
+			Type:   domain.IntentInvokeTool,
+			ToolID: "local.tool",
+		},
+	})
+	if err != nil {
+		t.Fatalf("invoke tool: %v", err)
+	}
+	if !result.Accepted {
+		t.Fatalf("expected accepted, got error: %s", result.Error)
+	}
+	stepID := result.StepID
+
+	state, err := k.GetExecution(ctx, execID)
+	if err != nil {
+		t.Fatalf("get execution: %v", err)
+	}
+	if state.CurrentStep == nil || state.CurrentStep.Status.IsTerminal() {
+		t.Fatal("expected non-terminal current step before disconnect")
+	}
+
+	k.HandleAgentDisconnect(ctx, sessionID)
+
+	events.mu.Lock()
+	var foundStepCancelled bool
+	for _, evt := range events.events[execID] {
+		if evt.Type == domain.EventStepCancelled && evt.StepID == stepID {
+			foundStepCancelled = true
+		}
+	}
+	events.mu.Unlock()
+
+	if !foundStepCancelled {
+		t.Fatal("expected step.cancelled event for orphaned step after disconnect")
+	}
+
+	state, err = k.GetExecution(ctx, execID)
+	if err != nil {
+		t.Fatalf("get execution after disconnect: %v", err)
+	}
+	if state.Execution.Status != domain.ExecutionPending {
+		t.Fatalf("expected pending, got %s", state.Execution.Status)
+	}
+	if state.CurrentStep != nil {
+		t.Fatal("expected CurrentStep to be nil after reset")
+	}
+}
+
+func TestHandleAgentDisconnectAllowsNewToolAfterReassignment(t *testing.T) {
+	k, _, _, _, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+
+	result, err := k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent: domain.Intent{
+			Type:   domain.IntentInvokeTool,
+			ToolID: "local.tool",
+		},
+	})
+	if err != nil {
+		t.Fatalf("invoke tool: %v", err)
+	}
+	if !result.Accepted {
+		t.Fatalf("expected accepted, got error: %s", result.Error)
+	}
+
+	k.HandleAgentDisconnect(ctx, sessionID)
+
+	newSessionID := "new-session-" + execID[:8]
+	sessions.Create(ctx, domain.Session{
+		ID:          newSessionID,
+		ExecutionID: execID,
+		AgentID:     "agent-1",
+		ConsumerID:  "consumer-2",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(2 * time.Minute),
+	})
+	k.EmitEvent(ctx, execID, "", domain.EventExecutionStarted, nil, uuid.Nil, uuid.Nil)
+	k.events.UpdateExecutionStatus(ctx, execID, domain.ExecutionRunning)
+
+	result, err = k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   newSessionID,
+		Intent: domain.Intent{
+			Type:      domain.IntentInvokeTool,
+			ToolID:    "another.tool",
+			Arguments: json.RawMessage(`{}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("new agent invoke tool after reassignment: %v", err)
+	}
+	if !result.Accepted {
+		t.Fatalf("expected accepted after reassignment, got error: %s", result.Error)
+	}
+}
+
+func TestHandleAgentDisconnectSkipsTerminalSteps(t *testing.T) {
+	k, events, _, _, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+
+	result, err := k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent: domain.Intent{
+			Type:   domain.IntentInvokeTool,
+			ToolID: "local.tool",
+		},
+	})
+	if err != nil {
+		t.Fatalf("invoke tool: %v", err)
+	}
+
+	k.SubmitStepResult(ctx, StepResultRequest{
+		ExecutionID: execID,
+		StepID:      result.StepID,
+		SessionID:   sessionID,
+		Success:     true,
+		Data:        json.RawMessage(`{"ok":true}`),
+	})
+
+	k.HandleAgentDisconnect(ctx, sessionID)
+
+	events.mu.Lock()
+	cancelCount := 0
+	for _, evt := range events.events[execID] {
+		if evt.Type == domain.EventStepCancelled {
+			cancelCount++
+		}
+	}
+	events.mu.Unlock()
+
+	if cancelCount != 0 {
+		t.Fatalf("expected no step.cancelled events for already-terminal step, got %d", cancelCount)
+	}
+}
+
+func TestHandleAgentDisconnectTerminalExecutionNoOp(t *testing.T) {
+	k, events, _, _, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+
+	k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent:      domain.Intent{Type: domain.IntentComplete, Output: json.RawMessage(`{}`)},
+	})
+
+	events.mu.Lock()
+	countBefore := len(events.events[execID])
+	events.mu.Unlock()
+
+	k.HandleAgentDisconnect(ctx, sessionID)
+
+	events.mu.Lock()
+	countAfter := len(events.events[execID])
+	events.mu.Unlock()
+
+	if countAfter != countBefore {
+		t.Fatalf("expected no new events after disconnect on terminal execution, before=%d after=%d", countBefore, countAfter)
+	}
+}

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -202,6 +202,19 @@ func (m *Manager) reassignIfNeeded(ctx context.Context, executionID, agentID, ca
 
 	switch state.Execution.Status {
 	case domain.ExecutionRunning, domain.ExecutionBlocked:
+		for stepID, step := range state.Steps {
+			if step.Status.IsTerminal() {
+				continue
+			}
+			if _, err := m.emitter.EmitEvent(ctx, executionID, stepID, domain.EventStepCancelled,
+				domain.StepCancelledPayload{Reason: "agent disconnected"}, uuid.Nil, uuid.Nil); err != nil {
+				m.logger.Warn(caller+": failed to cancel orphaned step",
+					slog.String("execution_id", executionID),
+					slog.String("step_id", stepID),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
 		if _, err := m.emitter.EmitEvent(ctx, executionID, "", domain.EventAgentTimeout,
 			domain.AgentTimeoutPayload{SessionID: ""}, uuid.Nil, uuid.Nil); err != nil {
 			m.logger.Warn(caller+": failed to emit agent.timeout for reassignment",

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -506,6 +506,79 @@ func TestReapSessionsOrphanedPendingExecutionNotReassigned(t *testing.T) {
 	}
 }
 
+func stepCreatedEvent(stepID string, seq int64) domain.Event {
+	return domain.Event{
+		StepID:   stepID,
+		Type:     domain.EventStepCreated,
+		Payload:  mustMarshal(domain.StepCreatedPayload{ToolID: "local.tool", Attempt: 1}),
+		Sequence: seq,
+	}
+}
+
+func TestRecoverActiveExecutionsCancelsOrphanedSteps(t *testing.T) {
+	f := newTestFixture()
+
+	execID := "exec-orphan-step"
+	f.events.activeIDs = []string{execID}
+	f.events.events[execID] = []domain.Event{
+		createdEvent("agent-1", 1),
+		startedEvent(2),
+		stepCreatedEvent("step-1", 3),
+	}
+
+	m := f.manager(time.Hour)
+	m.RecoverActiveExecutions(context.Background())
+
+	f.emitter.mu.Lock()
+	defer f.emitter.mu.Unlock()
+
+	foundStepCancelled := false
+	for _, e := range f.emitter.events {
+		if e.EventType == domain.EventStepCancelled && e.StepID == "step-1" {
+			foundStepCancelled = true
+		}
+	}
+	if !foundStepCancelled {
+		t.Error("expected step.cancelled event for orphaned step during recovery")
+	}
+
+	status, ok := f.events.statusUpdates[execID]
+	if !ok {
+		t.Fatal("expected status update for orphaned execution")
+	}
+	if status != domain.ExecutionPending {
+		t.Fatalf("expected status pending, got %s", status)
+	}
+}
+
+func TestReapSessionsCancelsOrphanedSteps(t *testing.T) {
+	f := newTestFixture()
+	f.sessions.deletedExpired = 1
+	execID := "exec-orphan-step"
+	f.events.activeIDs = []string{execID}
+	f.events.events[execID] = []domain.Event{
+		createdEvent("agent-1", 1),
+		startedEvent(2),
+		stepCreatedEvent("step-1", 3),
+	}
+
+	m := f.manager(time.Hour)
+	m.reapSessions(context.Background())
+
+	f.emitter.mu.Lock()
+	defer f.emitter.mu.Unlock()
+
+	foundStepCancelled := false
+	for _, e := range f.emitter.events {
+		if e.EventType == domain.EventStepCancelled && e.StepID == "step-1" {
+			foundStepCancelled = true
+		}
+	}
+	if !foundStepCancelled {
+		t.Error("expected step.cancelled event for orphaned step during session reaping")
+	}
+}
+
 func mustMarshal(v any) json.RawMessage {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/internal/projector/handle_execution.go
+++ b/internal/projector/handle_execution.go
@@ -104,5 +104,7 @@ func applyExecutionReset(state *domain.ExecutionState, evt *domain.Event) error 
 	state.Execution.UpdatedAt = evt.Timestamp
 	state.BlockedReason = ""
 	state.BlockedRef = ""
+	state.CurrentStep = nil
+	state.PendingApproval = nil
 	return nil
 }

--- a/internal/projector/projector_test.go
+++ b/internal/projector/projector_test.go
@@ -829,3 +829,67 @@ func TestResumedClearsPendingApproval(t *testing.T) {
 		t.Fatal("expected PendingApproval cleared after resume")
 	}
 }
+
+func TestResetClearsCurrentStepAndPendingApproval(t *testing.T) {
+	state := emptyState()
+	applyExecutionCreated(state, makeEvent("e1", 1, domain.EventExecutionCreated,
+		domain.ExecutionCreatedPayload{AgentID: "a1"}))
+	applyExecutionStarted(state, makeEvent("e1", 2, domain.EventExecutionStarted, nil))
+	applyStepCreated(state, makeStepEvent("e1", "s1", 3, domain.EventStepCreated,
+		domain.StepCreatedPayload{ToolID: "tool-a", Attempt: 1}))
+
+	if state.CurrentStep == nil {
+		t.Fatal("expected CurrentStep to be set before reset")
+	}
+
+	applyStepCancelled(state, makeStepEvent("e1", "s1", 4, domain.EventStepCancelled,
+		domain.StepCancelledPayload{Reason: "agent disconnected"}))
+	applyExecutionReset(state, makeEvent("e1", 5, domain.EventExecutionReset,
+		domain.ExecutionResetPayload{Reason: "agent_disconnect", FromStatus: "running"}))
+
+	if state.Execution.Status != domain.ExecutionPending {
+		t.Fatalf("expected pending after reset, got %s", state.Execution.Status)
+	}
+	if state.CurrentStep != nil {
+		t.Fatal("expected CurrentStep to be nil after reset")
+	}
+	if state.PendingApproval != nil {
+		t.Fatal("expected PendingApproval to be nil after reset")
+	}
+}
+
+func TestResetClearsBlockedApprovalState(t *testing.T) {
+	state := emptyState()
+	applyExecutionCreated(state, makeEvent("e1", 1, domain.EventExecutionCreated,
+		domain.ExecutionCreatedPayload{AgentID: "a1"}))
+	applyExecutionStarted(state, makeEvent("e1", 2, domain.EventExecutionStarted, nil))
+	applyStepCreated(state, makeStepEvent("e1", "s1", 3, domain.EventStepCreated,
+		domain.StepCreatedPayload{ToolID: "tool-a", Attempt: 1}))
+	applyExecutionBlocked(state, makeEvent("e1", 4, domain.EventExecutionBlocked,
+		domain.ExecutionBlockedPayload{Reason: "approval", Ref: "s1", ToolID: "tool-a"}))
+
+	if state.PendingApproval == nil {
+		t.Fatal("expected PendingApproval set before reset")
+	}
+	if state.CurrentStep == nil {
+		t.Fatal("expected CurrentStep set before reset")
+	}
+
+	applyStepCancelled(state, makeStepEvent("e1", "s1", 5, domain.EventStepCancelled,
+		domain.StepCancelledPayload{Reason: "agent disconnected"}))
+	applyExecutionReset(state, makeEvent("e1", 6, domain.EventExecutionReset,
+		domain.ExecutionResetPayload{Reason: "recovery", FromStatus: "blocked"}))
+
+	if state.Execution.Status != domain.ExecutionPending {
+		t.Fatalf("expected pending, got %s", state.Execution.Status)
+	}
+	if state.CurrentStep != nil {
+		t.Fatal("expected CurrentStep nil after reset")
+	}
+	if state.PendingApproval != nil {
+		t.Fatal("expected PendingApproval nil after reset")
+	}
+	if state.BlockedReason != "" {
+		t.Fatalf("expected empty blocked reason, got %s", state.BlockedReason)
+	}
+}


### PR DESCRIPTION
## Summary
- Cancel all non-terminal steps before resetting execution in `HandleAgentDisconnect` and `reassignIfNeeded`, matching the pattern already used in `CancelExecution`
- Clear `CurrentStep` and `PendingApproval` in the projector's `applyExecutionReset` so reassigned executions start with clean state
- Add comprehensive tests covering disconnect with orphaned steps, reassignment after disconnect, session reaper recovery, and projector reset behavior

Closes #4

## Test plan
- [x] `TestHandleAgentDisconnectCancelsOrphanedSteps` — verifies step.cancelled is emitted and CurrentStep cleared
- [x] `TestHandleAgentDisconnectAllowsNewToolAfterReassignment` — verifies new agent can invoke tools after disconnect+reassignment (the exact scenario from the bug)
- [x] `TestHandleAgentDisconnectSkipsTerminalSteps` — verifies already-completed steps are not cancelled
- [x] `TestHandleAgentDisconnectTerminalExecutionNoOp` — verifies no events emitted for terminal executions
- [x] `TestRecoverActiveExecutionsCancelsOrphanedSteps` — verifies lifecycle recovery path cancels orphaned steps
- [x] `TestReapSessionsCancelsOrphanedSteps` — verifies session reaper path cancels orphaned steps
- [x] `TestResetClearsCurrentStepAndPendingApproval` — verifies projector clears state on reset
- [x] `TestResetClearsBlockedApprovalState` — verifies projector clears approval state on reset from blocked
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)