### PR TITLE
Fix execution stuck in RUNNING after kernel restart

### DIFF
--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -193,6 +193,12 @@ func (s *stubSessionStore) Delete(_ context.Context, id string) error {
 	delete(s.sessions, id)
 	return nil
 }
+func (s *stubSessionStore) DeleteAll(_ context.Context) (int, error) {
+	count := len(s.sessions)
+	s.sessions = make(map[string]*domain.Session)
+	return count, nil
+}
+
 func (s *stubSessionStore) DeleteExpired(_ context.Context, _ time.Duration) (int, error) {
 	return 0, nil
 }

--- a/internal/kernel/mock_test.go
+++ b/internal/kernel/mock_test.go
@@ -340,6 +340,14 @@ func (m *mockSessionStore) Delete(_ context.Context, sessionID string) error {
 	return nil
 }
 
+func (m *mockSessionStore) DeleteAll(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := len(m.sessions)
+	m.sessions = make(map[string]*domain.Session)
+	return count, nil
+}
+
 func (m *mockSessionStore) DeleteExpired(_ context.Context, _ time.Duration) (int, error) {
 	return 0, nil
 }

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -109,11 +109,9 @@ func (m *Manager) reapSessions(ctx context.Context) {
 		return
 	}
 
-	if deleted == 0 {
-		return
+	if deleted > 0 {
+		m.logger.Info("session reaper: deleted expired sessions", slog.Int("count", deleted))
 	}
-
-	m.logger.Info("session reaper: deleted expired sessions", slog.Int("count", deleted))
 
 	activeIDs, err := m.events.ListActiveExecutionIDs(ctx)
 	if err != nil {
@@ -545,6 +543,14 @@ func (m *Manager) cleanupTerminalExecutions(ctx context.Context, retentionPeriod
 }
 
 func (m *Manager) RecoverActiveExecutions(ctx context.Context) {
+	if purged, err := m.sessions.DeleteAll(ctx); err != nil {
+		m.logger.Error("recovery: failed to purge stale sessions",
+			slog.String("error", err.Error()),
+		)
+	} else if purged > 0 {
+		m.logger.Info("recovery: purged stale sessions", slog.Int("count", purged))
+	}
+
 	ids, err := m.events.ListActiveExecutionIDs(ctx)
 	if err != nil {
 		m.logger.Error("recovery: failed to list active execution IDs",
@@ -569,7 +575,6 @@ func (m *Manager) RecoverActiveExecutions(ctx context.Context) {
 		}
 
 		if state.Execution.Status.IsTerminal() {
-			// Reconcile stale status column with the event-sourced state.
 			if err := m.events.UpdateExecutionStatus(ctx, execID, state.Execution.Status); err != nil {
 				m.logger.Warn("recovery: failed to reconcile terminal status",
 					slog.String("execution_id", execID),
@@ -577,18 +582,6 @@ func (m *Manager) RecoverActiveExecutions(ctx context.Context) {
 					slog.String("error", err.Error()),
 				)
 			}
-			continue
-		}
-
-		_, found, err := m.sessions.GetByExecution(ctx, execID)
-		if err != nil {
-			m.logger.Warn("recovery: failed to check session",
-				slog.String("execution_id", execID),
-				slog.String("error", err.Error()),
-			)
-			continue
-		}
-		if found {
 			continue
 		}
 

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -304,7 +304,7 @@ func TestRecoverActiveExecutions(t *testing.T) {
 		}
 	})
 
-	t.Run("execution with active session is not reassigned", func(t *testing.T) {
+	t.Run("execution with stale session is recovered after purge", func(t *testing.T) {
 		f := newTestFixture()
 
 		execID := "exec-active"
@@ -322,8 +322,16 @@ func TestRecoverActiveExecutions(t *testing.T) {
 		m := f.manager(time.Hour)
 		m.RecoverActiveExecutions(context.Background())
 
-		if _, ok := f.events.statusUpdates[execID]; ok {
-			t.Fatal("did not expect status update for execution with active session")
+		status, ok := f.events.statusUpdates[execID]
+		if !ok {
+			t.Fatal("expected status update after stale session purge")
+		}
+		if status != domain.ExecutionPending {
+			t.Fatalf("expected status pending, got %s", status)
+		}
+
+		if len(f.sessions.sessions) != 0 {
+			t.Fatal("expected all sessions to be purged")
 		}
 	})
 

--- a/internal/lifecycle/mock_test.go
+++ b/internal/lifecycle/mock_test.go
@@ -232,6 +232,14 @@ func (m *mockSessionStore) Delete(_ context.Context, sessionID string) error {
 	return nil
 }
 
+func (m *mockSessionStore) DeleteAll(_ context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := len(m.sessions)
+	m.sessions = make(map[string]*domain.Session)
+	return count, nil
+}
+
 func (m *mockSessionStore) DeleteExpired(_ context.Context, _ time.Duration) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/memstore/session.go
+++ b/internal/memstore/session.go
@@ -80,6 +80,15 @@ func (s *SessionStore) Delete(_ context.Context, sessionID string) error {
 	return nil
 }
 
+func (s *SessionStore) DeleteAll(_ context.Context) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := len(s.sessions)
+	s.sessions = make(map[string]domain.Session)
+	s.byExec = make(map[string]string)
+	return count, nil
+}
+
 func (s *SessionStore) DeleteExpired(_ context.Context, gracePeriod time.Duration) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/postgres/session_store.go
+++ b/internal/postgres/session_store.go
@@ -97,6 +97,14 @@ func (s *SessionStore) Delete(ctx context.Context, sessionID string) error {
 	return nil
 }
 
+func (s *SessionStore) DeleteAll(ctx context.Context) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM sessions`)
+	if err != nil {
+		return 0, fmt.Errorf("delete all sessions: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 func (s *SessionStore) DeleteExpired(ctx context.Context, gracePeriod time.Duration) (int, error) {
 	tag, err := s.pool.Exec(ctx,
 		`DELETE FROM sessions WHERE expires_at < now() - $1::interval`,

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -14,4 +14,5 @@ type SessionStore interface {
 	Extend(ctx context.Context, sessionID string, duration time.Duration) error
 	Delete(ctx context.Context, sessionID string) error
 	DeleteExpired(ctx context.Context, gracePeriod time.Duration) (int, error)
+	DeleteAll(ctx context.Context) (int, error)
 }


### PR DESCRIPTION
## Summary

- **Primary fix:** Purge all sessions at kernel startup before running `RecoverActiveExecutions`. After a restart, no SSE connections survive, so all persisted sessions are stale. Previously, `RecoverActiveExecutions` would see these stale sessions and skip recovery, leaving executions stuck in `running` indefinitely.
- **Secondary fix:** Decouple the session reaper's orphan scan from session deletion. Previously `reapSessions` returned early when `deleted == 0`, skipping the orphan check entirely. Now the orphan scan runs on every tick regardless of whether expired sessions were found.
- Add `DeleteAll` method to `SessionStore` interface with implementations for memstore and PostgreSQL.

Closes #2

## Test plan

- [x] Updated existing test to verify stale sessions are purged and stuck executions are recovered
- [x] All lifecycle, memstore, kernel, and API tests pass
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)