### PR TITLE
Fix double-claim race in buildClaimResult

### DIFF
--- a/internal/kernel/claim.go
+++ b/internal/kernel/claim.go
@@ -40,6 +40,10 @@ func (k *Kernel) buildClaimResult(ctx context.Context, executionID, agentID, con
 	if err != nil {
 		return nil, fmt.Errorf("projecting execution %s: %w", executionID, err)
 	}
+	if state.Execution.Status != domain.ExecutionPending {
+		return nil, fmt.Errorf("%w: execution %s is %s, not pending",
+			domain.ErrConflict, executionID, state.Execution.Status)
+	}
 
 	sessionID := uuid.Must(uuid.NewV7()).String()
 	session := domain.Session{

--- a/internal/kernel/claim_test.go
+++ b/internal/kernel/claim_test.go
@@ -3,6 +3,7 @@ package kernel
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/rebuno/rebuno/internal/domain"
@@ -41,6 +42,27 @@ func TestBuildClaimResult(t *testing.T) {
 	}
 	if !foundStarted {
 		t.Fatal("expected execution.started event")
+	}
+}
+
+func TestBuildClaimResultRejectsNonPending(t *testing.T) {
+	k, _, _, _, _, _ := newConnectedTestKernel()
+	ctx := context.Background()
+
+	execID, err := k.CreateExecution(ctx, CreateExecutionRequest{
+		AgentID: "agent-1",
+		Input:   json.RawMessage(`{"query":"hello"}`),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = k.buildClaimResult(ctx, execID, "agent-2", "consumer-2")
+	if err == nil {
+		t.Fatal("expected error when claiming an already-running execution")
+	}
+	if !errors.Is(err, domain.ErrConflict) {
+		t.Fatalf("expected ErrConflict, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a status guard in `buildClaimResult` that checks the execution is still `pending` after acquiring the lock and projecting state. Returns `ErrConflict` if the execution has already been claimed by another agent.
- Adds a test (`TestBuildClaimResultRejectsNonPending`) that verifies a second claim attempt on an already-running execution is rejected.

Closes #6

## Test plan
- [x] `TestBuildClaimResultRejectsNonPending` — creates an execution (auto-claimed by connected agent), then attempts a second claim and asserts `ErrConflict`
- [x] All existing kernel tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)