### PR TITLE
Fix local steps never timing out

### DIFF
--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -116,6 +116,7 @@ type StepCreatedPayload struct {
 	Arguments   json.RawMessage `json:"arguments"`
 	MaxAttempts int             `json:"max_attempts"`
 	Attempt     int             `json:"attempt"`
+	Deadline    time.Time       `json:"deadline,omitempty"`
 }
 
 type StepDispatchedPayload struct {

--- a/internal/kernel/intent.go
+++ b/internal/kernel/intent.go
@@ -188,6 +188,7 @@ func (k *Kernel) executeInvokeTool(
 		Arguments:   req.Intent.Arguments,
 		MaxAttempts: 1,
 		Attempt:     1,
+		Deadline:    deadline,
 	}
 
 	if req.Intent.Remote {

--- a/internal/kernel/intent_test.go
+++ b/internal/kernel/intent_test.go
@@ -177,6 +177,42 @@ func TestProcessIntentInvokeTool(t *testing.T) {
 	}
 }
 
+func TestProcessIntentInvokeToolLocalStepHasDeadline(t *testing.T) {
+	k, _, _, _, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+	before := time.Now()
+
+	result, err := k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent: domain.Intent{
+			Type:   domain.IntentInvokeTool,
+			ToolID: "web.search",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Accepted {
+		t.Fatalf("expected accepted, got error: %s", result.Error)
+	}
+
+	state, _ := k.GetExecution(ctx, execID)
+	step := state.Steps[result.StepID]
+	if step == nil {
+		t.Fatal("expected step to exist")
+	}
+	if step.Deadline == nil {
+		t.Fatal("expected local step to have a deadline set")
+	}
+	expectedMin := before.Add(k.config.StepTimeout)
+	if step.Deadline.Before(expectedMin) {
+		t.Fatalf("deadline %v is before expected minimum %v", *step.Deadline, expectedMin)
+	}
+}
+
 func TestProcessIntentInvokeToolRemote(t *testing.T) {
 	k, _, _, runnerHub, sessions, _ := newTestKernel()
 	ctx := context.Background()

--- a/internal/projector/handle_step.go
+++ b/internal/projector/handle_step.go
@@ -35,6 +35,9 @@ func applyStepCreated(state *domain.ExecutionState, evt *domain.Event) error {
 		Arguments:   payload.Arguments,
 		CreatedAt:   evt.Timestamp,
 	}
+	if !payload.Deadline.IsZero() {
+		step.Deadline = &payload.Deadline
+	}
 	if state.Steps == nil {
 		state.Steps = make(map[string]*domain.Step)
 	}


### PR DESCRIPTION
## Summary
- Add `Deadline` field to `StepCreatedPayload` so all steps (local and remote) carry a deadline from creation
- Set the computed `deadline` in `StepCreatedPayload` in `executeInvokeTool` for all steps
- Update `applyStepCreated` in the projector to populate `step.Deadline` from the payload
- Add test verifying local steps have a deadline set

Closes #7

## Test plan
- [x] Existing kernel, projector, and lifecycle tests pass
- [x] New `TestProcessIntentInvokeToolLocalStepHasDeadline` verifies the deadline is set on local steps
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)