### PR TITLE
Fix step.retried projector handler to reset step state for retries

### DIFF
--- a/internal/kernel/runner_test.go
+++ b/internal/kernel/runner_test.go
@@ -111,6 +111,78 @@ func TestSubmitJobResultFailureWithRetry(t *testing.T) {
 	}
 }
 
+func TestSubmitJobResultRetryRoundTrip(t *testing.T) {
+	k, _, _, runnerHub, sessions, _ := newTestKernel()
+	ctx := context.Background()
+
+	execID, sessionID := setupRunningExecution(t, k, sessions)
+
+	result, _ := k.ProcessIntent(ctx, domain.IntentRequest{
+		ExecutionID: execID,
+		SessionID:   sessionID,
+		Intent: domain.Intent{
+			Type:   domain.IntentInvokeTool,
+			ToolID: "web.search",
+			Remote: true,
+		},
+	})
+
+	retryCh := make(chan struct{}, 1)
+	runnerHub.mu.Lock()
+	runnerHub.dispatched = nil
+	runnerHub.onDispatch = func() {
+		select {
+		case retryCh <- struct{}{}:
+		default:
+		}
+	}
+	runnerHub.mu.Unlock()
+
+	err := k.SubmitJobResult(ctx, domain.JobResult{
+		ExecutionID: execID,
+		StepID:      result.StepID,
+		RunnerID:    "mock-runner",
+		Success:     false,
+		Error:       "timeout",
+		Retryable:   true,
+	})
+	if err != nil {
+		t.Fatalf("submit retryable failure: %v", err)
+	}
+
+	select {
+	case <-retryCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for retry dispatch")
+	}
+
+	state, _ := k.GetExecution(ctx, execID)
+	step := state.Steps[result.StepID]
+	if step.Status != domain.StepPending {
+		t.Fatalf("expected step pending after retry, got %s", step.Status)
+	}
+	if step.Attempt != 2 {
+		t.Fatalf("expected attempt 2, got %d", step.Attempt)
+	}
+
+	err = k.SubmitJobResult(ctx, domain.JobResult{
+		ExecutionID: execID,
+		StepID:      result.StepID,
+		RunnerID:    "mock-runner",
+		Success:     true,
+		Data:        json.RawMessage(`{"results":["a","b"]}`),
+	})
+	if err != nil {
+		t.Fatalf("submit retry result: %v", err)
+	}
+
+	state, _ = k.GetExecution(ctx, execID)
+	step = state.Steps[result.StepID]
+	if step.Status != domain.StepSucceeded {
+		t.Fatalf("expected step succeeded after retry, got %s", step.Status)
+	}
+}
+
 func TestSubmitJobResultFailureNoRetry(t *testing.T) {
 	k, _, _, _, sessions, _ := newTestKernel()
 	ctx := context.Background()

--- a/internal/projector/handle_step.go
+++ b/internal/projector/handle_step.go
@@ -15,7 +15,7 @@ func registerStepHandlers(p *Projector) {
 	p.Register(domain.EventStepFailed, applyStepFailed)
 	p.Register(domain.EventStepTimedOut, applyStepTimedOut)
 	p.Register(domain.EventStepCancelled, applyStepCancelled)
-	p.Register(domain.EventStepRetried, noOp)
+	p.Register(domain.EventStepRetried, applyStepRetried)
 }
 
 func applyStepCreated(state *domain.ExecutionState, evt *domain.Event) error {
@@ -148,6 +148,25 @@ func applyStepTimedOut(state *domain.ExecutionState, evt *domain.Event) error {
 		CompletedAt: step.CompletedAt,
 	}
 	state.History = append(state.History, entry)
+	return nil
+}
+
+func applyStepRetried(state *domain.ExecutionState, evt *domain.Event) error {
+	step := state.Steps[evt.StepID]
+	if step == nil {
+		return fmt.Errorf("step.retried for unknown step %s", evt.StepID)
+	}
+
+	var payload domain.StepRetriedPayload
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		return fmt.Errorf("unmarshal step.retried payload: %w", err)
+	}
+
+	step.Status = domain.StepPending
+	step.Attempt = payload.NextAttempt
+	step.Error = ""
+	step.CompletedAt = nil
+	step.Retryable = false
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Replace the no-op `step.retried` projector handler with `applyStepRetried`, which resets the step from terminal `failed` state back to `pending`, updates the attempt counter, and clears error fields
- Add `TestSubmitJobResultRetryRoundTrip` test that exercises the full retry lifecycle: retryable failure → step reset → retry result accepted → step succeeds

Fixes #5

## Test plan

- [x] `TestSubmitJobResultRetryRoundTrip` verifies the full round-trip: fail with retryable error → retry dispatched → step reset to pending with incremented attempt → retry result submitted successfully → step reaches succeeded
- [x] All existing `TestSubmitJobResult*` tests continue to pass
- [x] All projector tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)